### PR TITLE
Typo fix: hashing -> hasing

### DIFF
--- a/server/example.env
+++ b/server/example.env
@@ -1,2 +1,2 @@
 MONGO_URI="your_mongodb_connection_string"
-SECRET_KEY="your_secret_key_for_jwt_hasing"
+SECRET_KEY="your_secret_key_for_jwt_hashing"


### PR DESCRIPTION
Example.env had a minor typo