### PR TITLE
Fix/rate limit middleware

### DIFF
--- a/server/controllers/taskControllers.go
+++ b/server/controllers/taskControllers.go
@@ -21,231 +21,246 @@ func getContextWithTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 10*time.Second)
 }
 
-func HealthCheck(c *gin.Context) {
-	myData := map[string]string{"version": "1.0"}
-	helper.RespondWithSuccess(c, http.StatusOK, "Health check", myData)
+// HealthCheck - Health endpoint, returns a simple status response
+func HealthCheck() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		myData := map[string]string{"version": "1.0"}
+		helper.RespondWithSuccess(c, http.StatusOK, "Health check", myData)
+	}
 }
 
 // GetTasks - Retrieves all tasks
-func GetTasks(c *gin.Context) {
-	userID, username, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
-		return
-	}
-
-	ctx, cancel := getContextWithTimeout()
-	defer cancel()
-
-	taskCollection := database.GetTaskCollection()
-	filter := bson.M{"userid": userID}
-
-	opts := options.Find().SetSort(bson.D{{Key: "created", Value: -1}})
-
-	cursor, err := taskCollection.Find(ctx, filter, opts)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error fetching tasks", err.Error())
-		return
-	}
-	defer cursor.Close(ctx)
-
-	var tasks []model.Task
-	if err = cursor.All(ctx, &tasks); err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error decoding tasks", err.Error())
-		return
-	}
-
-	if len(tasks) == 0 {
-		helper.RespondWithSuccess(c, http.StatusOK, "No tasks found for "+username, []model.Task{})
-		return
-	}
-
-	helper.RespondWithSuccess(c, http.StatusOK, "Tasks for "+username, tasks)
-}
-
-// GetTaskByID - Retrieves a single task with the specified ID
-func GetTaskByID(c *gin.Context) {
-	userID, username, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
-		return
-	}
-
-	taskId := c.Param("id")
-	if taskId == "" {
-		helper.RespondWithError(c, http.StatusBadRequest, "Task ID is required", "No ID provided in the request")
-		return
-	}
-
-	objId, err := primitive.ObjectIDFromHex(taskId)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Invalid task ID format", err.Error())
-		return
-	}
-
-	ctx, cancel := getContextWithTimeout()
-	defer cancel()
-
-	taskCollection := database.GetTaskCollection()
-	filter := bson.M{"_id": objId, "userid": userID}
-
-	var task model.Task
-	err = taskCollection.FindOne(ctx, filter).Decode(&task)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user "+username)
+func GetTasks() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, username, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
 			return
 		}
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error fetching task", err.Error())
-		return
-	}
 
-	helper.RespondWithSuccess(c, http.StatusOK, "Task for "+username, task)
+		ctx, cancel := getContextWithTimeout()
+		defer cancel()
+
+		taskCollection := database.GetTaskCollection()
+		filter := bson.M{"userid": userID}
+
+		opts := options.Find().SetSort(bson.D{{Key: "created", Value: -1}})
+
+		cursor, err := taskCollection.Find(ctx, filter, opts)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error fetching tasks", err.Error())
+			return
+		}
+		defer cursor.Close(ctx)
+
+		var tasks []model.Task
+		if err = cursor.All(ctx, &tasks); err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error decoding tasks", err.Error())
+			return
+		}
+
+		if len(tasks) == 0 {
+			helper.RespondWithSuccess(c, http.StatusOK, "No tasks found for "+username, []model.Task{})
+			return
+		}
+
+		helper.RespondWithSuccess(c, http.StatusOK, "Tasks for "+username, tasks)
+	}
+}
+
+// GetTaskByID - Retrieves a single task by its ID
+func GetTaskByID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, username, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
+			return
+		}
+
+		taskId := c.Param("id")
+		if taskId == "" {
+			helper.RespondWithError(c, http.StatusBadRequest, "Task ID is required", "No ID provided in the request")
+			return
+		}
+
+		objId, err := primitive.ObjectIDFromHex(taskId)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Invalid task ID format", err.Error())
+			return
+		}
+
+		ctx, cancel := getContextWithTimeout()
+		defer cancel()
+
+		taskCollection := database.GetTaskCollection()
+		filter := bson.M{"_id": objId, "userid": userID}
+
+		var task model.Task
+		err = taskCollection.FindOne(ctx, filter).Decode(&task)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user "+username)
+				return
+			}
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error fetching task", err.Error())
+			return
+		}
+
+		helper.RespondWithSuccess(c, http.StatusOK, "Task for "+username, task)
+	}
 }
 
 // PostTask - Adds a task from JSON received in the request body
-func PostTask(c *gin.Context) {
-	var newTask model.Task
-	if err := c.ShouldBindJSON(&newTask); err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Invalid JSON input", err.Error())
-		return
+func PostTask() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var newTask model.Task
+		if err := c.ShouldBindJSON(&newTask); err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Invalid JSON input", err.Error())
+			return
+		}
+
+		userID, username, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Invalid user details", "Failed to get username or UID")
+			return
+		}
+
+		newTask.ID = primitive.NewObjectID()
+		newTask.UserID = userID
+		newTask.Username = username
+		newTask.Created = time.Now().UTC()
+		newTask.Updated = time.Time{}
+		newTask.Status = false
+
+		if err := validate.Struct(newTask); err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Validation error", err.Error())
+			return
+		}
+
+		collection := database.GetTaskCollection()
+		if _, err := collection.InsertOne(c.Request.Context(), newTask); err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error inserting task", err.Error())
+			return
+		}
+
+		helper.RespondWithSuccess(c, http.StatusCreated, "Task created successfully", newTask)
 	}
-
-	userID, username, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Invalid user details", "Failed to get username or UID")
-		return
-	}
-
-	newTask.ID = primitive.NewObjectID()
-	newTask.UserID = userID
-	newTask.Username = username
-	newTask.Created = time.Now().UTC()
-	newTask.Updated = time.Time{}
-	newTask.Status = false
-
-	if err := validate.Struct(newTask); err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Validation error", err.Error())
-		return
-	}
-
-	collection := database.GetTaskCollection()
-	if _, err := collection.InsertOne(c.Request.Context(), newTask); err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error inserting task", err.Error())
-		return
-	}
-
-	helper.RespondWithSuccess(c, http.StatusCreated, "Task created successfully", newTask)
 }
 
 // UpdateTask - Updates the task with the specified ID
-func UpdateTask(c *gin.Context) {
-	userID, username, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
-		return
-	}
+func UpdateTask() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, username, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID or Username not found in context")
+			return
+		}
 
-	idStr := c.Param("id")
-	id, err := primitive.ObjectIDFromHex(idStr)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Invalid ID format", err.Error())
-		return
-	}
+		idStr := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idStr)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Invalid ID format", err.Error())
+			return
+		}
 
-	var updatedFields struct {
-		Title   *string    `json:"title" validate:"omitempty,min=1"`
-		Status  *bool      `json:"status"`
-		Updated *time.Time `json:"updated"`
-	}
+		var updatedFields struct {
+			Title   *string    `json:"title" validate:"omitempty,min=1"`
+			Status  *bool      `json:"status"`
+			Updated *time.Time `json:"updated"`
+		}
 
-	if err := c.ShouldBindJSON(&updatedFields); err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Invalid JSON input", err.Error())
-		return
-	}
+		if err := c.ShouldBindJSON(&updatedFields); err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Invalid JSON input", err.Error())
+			return
+		}
 
-	if err := validate.Struct(updatedFields); err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Validation error", err.Error())
-		return
-	}
+		if err := validate.Struct(updatedFields); err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Validation error", err.Error())
+			return
+		}
 
-	update := bson.M{}
-	if updatedFields.Title != nil {
-		update["title"] = *updatedFields.Title
-	}
-	if updatedFields.Status != nil {
-		update["status"] = *updatedFields.Status
-	}
-	update["updated"] = time.Now().UTC()
+		update := bson.M{}
+		if updatedFields.Title != nil {
+			update["title"] = *updatedFields.Title
+		}
+		if updatedFields.Status != nil {
+			update["status"] = *updatedFields.Status
+		}
+		update["updated"] = time.Now().UTC()
 
-	collection := database.GetTaskCollection()
-	filter := bson.M{"_id": id, "userid": userID}
+		collection := database.GetTaskCollection()
+		filter := bson.M{"_id": id, "userid": userID}
 
-	result, err := collection.UpdateOne(c.Request.Context(), filter, bson.M{"$set": update})
-	if err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error updating task", err.Error())
-		return
+		result, err := collection.UpdateOne(c.Request.Context(), filter, bson.M{"$set": update})
+		if err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error updating task", err.Error())
+			return
+		}
+
+		if result.MatchedCount == 0 {
+			helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user "+username)
+			return
+		}
+
+		helper.RespondWithSuccess(c, http.StatusOK, "Task updated successfully for "+username, update)
 	}
-
-	if result.MatchedCount == 0 {
-		helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user "+username)
-		return
-	}
-
-	helper.RespondWithSuccess(c, http.StatusOK, "Task updated successfully for "+username, update)
 }
 
 // DeleteTask - Deletes the task with the specified ID
-func DeleteTask(c *gin.Context) {
-	userID, _, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID not found in context")
-		return
-	}
+func DeleteTask() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID not found in context")
+			return
+		}
 
-	idStr := c.Param("id")
-	id, err := primitive.ObjectIDFromHex(idStr)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusBadRequest, "Invalid ID format", err.Error())
-		return
-	}
+		idStr := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idStr)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusBadRequest, "Invalid ID format", err.Error())
+			return
+		}
 
-	collection := database.GetTaskCollection()
-	filter := bson.M{"_id": id, "userid": userID}
-	result, err := collection.DeleteOne(c.Request.Context(), filter)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error deleting task", err.Error())
-		return
-	}
+		collection := database.GetTaskCollection()
+		filter := bson.M{"_id": id, "userid": userID}
+		result, err := collection.DeleteOne(c.Request.Context(), filter)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error deleting task", err.Error())
+			return
+		}
 
-	if result.DeletedCount == 0 {
-		helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user")
-		return
-	}
+		if result.DeletedCount == 0 {
+			helper.RespondWithError(c, http.StatusNotFound, "Task not found", "No task found for the specified ID and user")
+			return
+		}
 
-	helper.RespondWithSuccess(c, http.StatusOK, "Task deleted successfully", nil)
+		helper.RespondWithSuccess(c, http.StatusOK, "Task deleted successfully", nil)
+	}
 }
 
-// DeleteAllTasks - Deletes all the tasks
-func DeleteAllTasks(c *gin.Context) {
-	userID, _, valid := helper.GetUserDetails(c)
-	if !valid {
-		helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID not found in context")
-		return
-	}
+// DeleteAllTasks - Deletes all tasks
+func DeleteAllTasks() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _, valid := helper.GetUserDetails(c)
+		if !valid {
+			helper.RespondWithError(c, http.StatusUnauthorized, "User not authorized", "UID not found in context")
+			return
+		}
 
-	collection := database.GetTaskCollection()
-	filter := bson.M{"userid": userID}
-	result, err := collection.DeleteMany(c.Request.Context(), filter)
-	if err != nil {
-		helper.RespondWithError(c, http.StatusInternalServerError, "Error deleting all tasks", err.Error())
-		return
-	}
+		collection := database.GetTaskCollection()
+		filter := bson.M{"userid": userID}
+		result, err := collection.DeleteMany(c.Request.Context(), filter)
+		if err != nil {
+			helper.RespondWithError(c, http.StatusInternalServerError, "Error deleting all tasks", err.Error())
+			return
+		}
 
-	if result.DeletedCount == 0 {
-		helper.RespondWithError(c, http.StatusNotFound, "No tasks found", "No tasks found for the user to delete")
-		return
-	}
+		if result.DeletedCount == 0 {
+			helper.RespondWithError(c, http.StatusNotFound, "No tasks found", "No tasks found for the user to delete")
+			return
+		}
 
-	helper.RespondWithSuccess(c, http.StatusOK, "All tasks deleted successfully", nil)
+		helper.RespondWithSuccess(c, http.StatusOK, "All tasks deleted successfully", nil)
+	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,10 +2,9 @@ module task-manager/server
 
 go 1.23.2
 
-require (
-	github.com/gin-gonic/gin v1.10.0
-	github.com/juju/ratelimit v1.0.2
-)
+require github.com/gin-gonic/gin v1.10.0
+
+require github.com/juju/ratelimit v1.0.2 // indirect
 
 require (
 	github.com/bytedance/sonic v1.12.5 // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,9 +2,15 @@ module task-manager/server
 
 go 1.23.2
 
-require github.com/gin-gonic/gin v1.10.0
-
-require github.com/juju/ratelimit v1.0.2 // indirect
+require (
+	github.com/gin-gonic/gin v1.10.0
+	github.com/go-playground/validator/v10 v10.23.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/joho/godotenv v1.5.1
+	github.com/juju/ratelimit v1.0.2
+	go.mongodb.org/mongo-driver v1.17.2
+	golang.org/x/crypto v0.33.0
+)
 
 require (
 	github.com/bytedance/sonic v1.12.5 // indirect
@@ -15,11 +21,8 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.23.0
 	github.com/goccy/go-json v0.10.3 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
@@ -35,9 +38,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	go.mongodb.org/mongo-driver v1.17.2
 	golang.org/x/arch v0.12.0 // indirect
-	golang.org/x/crypto v0.33.0
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/server/helpers/tokenHelper.go
+++ b/server/helpers/tokenHelper.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -31,38 +32,43 @@ const (
 	RefreshTokenExpiry = 128
 )
 
-func GenerateAllTokens(email, userName, userType, uid string) (string, string, error) {
+// Generate access and refresh tokens
+func GenerateAllTokens(email, userName, userType, uid string) (string, string, int64, int64, error) {
+	accessExpiry := time.Now().Add(time.Hour * time.Duration(AccessTokenExpiry)).Unix()
+	refreshExpiry := time.Now().Add(time.Hour * time.Duration(RefreshTokenExpiry)).Unix()
+
 	claims := &model.SignedDetails{
 		Email:    email,
 		Username: userName,
 		Uid:      uid,
 		UserType: userType,
 		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour * time.Duration(AccessTokenExpiry)).Unix(),
+			ExpiresAt: accessExpiry,
 		},
 	}
 
 	refreshClaims := &model.SignedDetails{
 		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Hour * time.Duration(RefreshTokenExpiry)).Unix(),
+			ExpiresAt: refreshExpiry,
 		},
 	}
 
 	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(hashKey))
 	if err != nil {
-		log.Printf("error generating access token: %v", err)
-		return "", "", err
+		log.Printf("Error generating access token: %v", err)
+		return "", "", 0, 0, err
 	}
 
 	refreshToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshClaims).SignedString([]byte(hashKey))
 	if err != nil {
-		log.Printf("error generating refresh token: %v", err)
-		return "", "", err
+		log.Printf("Error generating refresh token: %v", err)
+		return "", "", 0, 0, err
 	}
 
-	return token, refreshToken, nil
+	return token, refreshToken, accessExpiry, refreshExpiry, nil
 }
 
+// Validate token (checks expiration and claims)
 func ValidateToken(signedToken string) (claims *model.SignedDetails, msg string) {
 	token, err := jwt.ParseWithClaims(
 		signedToken,
@@ -73,20 +79,22 @@ func ValidateToken(signedToken string) (claims *model.SignedDetails, msg string)
 	)
 
 	if err != nil {
-		return nil, "error while parsing token: " + err.Error()
+		return nil, "Error while parsing token: " + err.Error()
 	}
 
 	claims, ok := token.Claims.(*model.SignedDetails)
 	if !ok {
-		return nil, "the token is invalid"
+		return nil, "Invalid token"
 	}
 
 	if claims.ExpiresAt < time.Now().Unix() {
-		return nil, "token is expired"
+		return nil, "Token is expired"
 	}
+
 	return claims, ""
 }
 
+// Update tokens in database
 func UpdateAllTokens(signedToken, signedRefreshToken, UserID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -103,11 +111,8 @@ func UpdateAllTokens(signedToken, signedRefreshToken, UserID string) error {
 	opt := options.UpdateOptions{Upsert: &upsert}
 
 	log.Printf("Updating tokens for user: %v", UserID)
-	log.Printf("filter: %v", filter)
-	log.Printf("updateObj: %v", updateObj)
 
 	userCollection := database.GetUserCollection()
-
 	if userCollection == nil {
 		log.Printf("Error: userCollection is nil")
 		return fmt.Errorf("userCollection is nil")
@@ -115,10 +120,38 @@ func UpdateAllTokens(signedToken, signedRefreshToken, UserID string) error {
 
 	_, err := userCollection.UpdateOne(ctx, filter, bson.D{{Key: "$set", Value: updateObj}}, &opt)
 	if err != nil {
-		log.Printf("failed to update tokens for user %s: %v", UserID, err)
+		log.Printf("Failed to update tokens for user %s: %v", UserID, err)
 		return err
 	}
 
 	log.Printf("Successfully updated tokens for user %s", UserID)
 	return nil
+}
+
+// Refresh access token using refresh token
+func RefreshToken(c *gin.Context) {
+	refreshToken, err := c.Cookie("refresh_token")
+	if err != nil {
+		RespondWithError(c, 401, "No refresh token provided", "")
+		return
+	}
+
+	claims, msg := ValidateToken(refreshToken)
+	if msg != "" {
+		RespondWithError(c, 401, "Invalid refresh token", msg)
+		return
+	}
+
+	newAccessToken, newRefreshToken, accessExpiry, refreshExpiry, err := GenerateAllTokens(
+		claims.Email, claims.Username, claims.UserType, claims.Uid,
+	)
+	if err != nil {
+		RespondWithError(c, 500, "Failed to generate new tokens", err.Error())
+		return
+	}
+
+	c.SetCookie("access_token", newAccessToken, int(accessExpiry-time.Now().Unix()), "/", "", true, true)
+	c.SetCookie("refresh_token", newRefreshToken, int(refreshExpiry-time.Now().Unix()), "/", "", true, true)
+
+	RespondWithSuccess(c, 200, "Token refreshed successfully", gin.H{"access_token": newAccessToken})
 }

--- a/server/middleware/rateLimit.go
+++ b/server/middleware/rateLimit.go
@@ -2,25 +2,46 @@ package middleware
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/juju/ratelimit"
+
+	helper "task-manager/server/helpers"
 )
 
-var (
-	SignupLimiter = ratelimit.NewBucketWithRate(5, 10)
-	LoginLimiter  = ratelimit.NewBucketWithRate(10, 20)
-	CreateLimiter = ratelimit.NewBucketWithRate(10, 20)
-	DeleteLimiter = ratelimit.NewBucketWithRate(10, 20)
-	HealthLimiter = ratelimit.NewBucketWithRate(10, 50)
-)
+var rateLimiters = make(map[string]map[string]*ratelimit.Bucket)
+var mu sync.Mutex
 
-func RateLimitMiddleware(rateLimiter *ratelimit.Bucket) gin.HandlerFunc {
+// Get a rate limiter for a specific route and IP
+func getRateLimiter(route string, ip string, rate float64, capacity int64) *ratelimit.Bucket {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, exists := rateLimiters[route]; !exists {
+		rateLimiters[route] = make(map[string]*ratelimit.Bucket)
+	}
+
+	if _, exists := rateLimiters[route][ip]; !exists {
+		rateLimiters[route][ip] = ratelimit.NewBucketWithRate(rate, capacity)
+	}
+
+	return rateLimiters[route][ip]
+}
+
+// RateLimitMiddleware creates a rate limiter for a specific route
+func RateLimitMiddleware(rate float64, capacity int64) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if rateLimiter.TakeAvailable(1) == 0 {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "Rate limit exceeded"})
+		clientIP := c.ClientIP()
+		route := c.FullPath()
+		bucket := getRateLimiter(route, clientIP, rate, capacity)
+
+		if bucket.TakeAvailable(1) == 0 {
+			helper.RespondWithError(c, http.StatusTooManyRequests, "Rate limit exceeded", "Too many requests for this route")
+			c.Abort()
 			return
 		}
+
 		c.Next()
 	}
 }

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -8,31 +8,26 @@ import (
 )
 
 func SetupRoutes(router *gin.Engine) {
-	// Health check route
-	HealthLimiter := middleware.RateLimitMiddleware(middleware.HealthLimiter)
 
-	router.GET("/health", HealthLimiter, controller.HealthCheck)
+	// Health check route
+	router.GET("/health", controller.HealthCheck())
 
 	// Authentication routes
-	signupRateLimiter := middleware.RateLimitMiddleware(middleware.SignupLimiter)
-	loginRateLimiter := middleware.RateLimitMiddleware(middleware.LoginLimiter)
+	router.POST("users/signup", controller.Signup())
+	router.POST("users/login", controller.Login())
+	router.POST("/users/logout", controller.Logout())
+	router.POST("/refresh", controller.RefreshAccessToken())
 
-	router.POST("users/signup", signupRateLimiter, controller.Signup())
-	router.POST("users/login", loginRateLimiter, controller.Login())
-
-	// User routes (protected with authentication middleware)
+	// Protected user routes
 	router.Use(middleware.Authenticate())
 	router.GET("/users", controller.GetUsers())
 	router.GET("/users/:userid", controller.GetUser())
 
 	// Task routes
-	taskCreateLimiter := middleware.RateLimitMiddleware(middleware.CreateLimiter)
-	taskDeleteLimiter := middleware.RateLimitMiddleware(middleware.DeleteLimiter)
-
-	router.GET("/tasks", controller.GetTasks)
-	router.GET("/tasks/:id", controller.GetTaskByID)
-	router.POST("/tasks", taskCreateLimiter, controller.PostTask)
-	router.PUT("/tasks/:id", controller.UpdateTask)
-	router.DELETE("/tasks/:id", controller.DeleteTask)
-	router.DELETE("/tasks", taskDeleteLimiter, controller.DeleteAllTasks)
+	router.GET("/tasks", controller.GetTasks())
+	router.GET("/tasks/:id", controller.GetTaskByID())
+	router.POST("/tasks", controller.PostTask())
+	router.PUT("/tasks/:id", controller.UpdateTask())
+	router.DELETE("/tasks/:id", controller.DeleteTask())
+	router.DELETE("/tasks/all", controller.DeleteAllTasks())
 }

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -8,26 +8,28 @@ import (
 )
 
 func SetupRoutes(router *gin.Engine) {
-
 	// Health check route
 	router.GET("/health", controller.HealthCheck())
 
 	// Authentication routes
-	router.POST("users/signup", controller.Signup())
-	router.POST("users/login", controller.Login())
+	router.POST("users/signup", middleware.RateLimitMiddleware(0.1, 1), controller.Signup())
+	router.POST("users/login", middleware.RateLimitMiddleware(0.1, 1), controller.Login())
 	router.POST("/users/logout", controller.Logout())
-	router.POST("/refresh", controller.RefreshAccessToken())
+	router.POST("/refresh", middleware.RateLimitMiddleware(0.5, 2), controller.RefreshAccessToken())
 
-	// Protected user routes
+	// Authenticate
 	router.Use(middleware.Authenticate())
-	router.GET("/users", controller.GetUsers())
-	router.GET("/users/:userid", controller.GetUser())
 
-	// Task routes
-	router.GET("/tasks", controller.GetTasks())
-	router.GET("/tasks/:id", controller.GetTaskByID())
-	router.POST("/tasks", controller.PostTask())
-	router.PUT("/tasks/:id", controller.UpdateTask())
-	router.DELETE("/tasks/:id", controller.DeleteTask())
-	router.DELETE("/tasks/all", controller.DeleteAllTasks())
+	// User Routes
+	router.GET("/users", middleware.RateLimitMiddleware(3, 6), controller.GetUsers())
+	router.GET("/users/:userid", middleware.RateLimitMiddleware(3, 5), controller.GetUser())
+
+	// Task Routes
+	router.GET("/tasks", middleware.RateLimitMiddleware(10, 20), controller.GetTasks())
+	router.GET("/tasks/:id", middleware.RateLimitMiddleware(3, 6), controller.GetTaskByID())
+
+	router.POST("/tasks", middleware.RateLimitMiddleware(1, 3), controller.PostTask())
+	router.PUT("/tasks/:id", middleware.RateLimitMiddleware(2, 5), controller.UpdateTask())
+	router.DELETE("/tasks/:id", middleware.RateLimitMiddleware(0.5, 1), controller.DeleteTask())
+	router.DELETE("/tasks/all", middleware.RateLimitMiddleware(0.5, 1), controller.DeleteAllTasks())
 }


### PR DESCRIPTION
**Rate Limit Middleware Implementation:**

This pull request introduces a rate limit middleware using the `github.com/juju/ratelimit` package. The rate limiter is designed to apply rate limiting to different routes in the application based on the user’s IP address. Key aspects of the implementation include:

- **Rate Limiter Configuration:**
  - The rate limiter takes the user’s IP address, the request route, the rate (tokens per second), and the capacity (total tokens allowed).
  - It uses a `sync.Mutex` to ensure thread safety and prevent race conditions when accessing or updating the rate limiters for specific routes and IPs.

- **Route-Specific Rate Limiting:**
  - The middleware is designed to be applied on a per-route basis, allowing different routes to have different rate limits, defined by the `rate` and `capacity` parameters.
  - The rate limiter dynamically creates and stores rate limiters for each combination of route and IP address in a global map (`rateLimiters`).

- **Middleware Usage:**
  - The rate limit middleware can be easily applied to any route by specifying the rate and capacity as arguments in the route definition. For example:
    ```go
    router.POST("users/signup", middleware.RateLimitMiddleware(0.1, 1), controller.Signup())
    ```

- **Handling Rate Limiting:**
  - When a user exceeds the rate limit for a specific route, the middleware returns a `429 Too Many Requests` error, preventing further requests until the rate limit resets.

**Changes in Routes:**

- The middleware has been applied to several routes with different rate limits. Example:
  - `/users/signup` and `/users/login` are rate-limited to 1 request per 10 seconds (0.1 rate, 1 capacity).
  - `/tasks` routes are rate-limited with different values depending on the action (e.g., `POST` for creating tasks, `GET` for retrieving tasks, etc.).
